### PR TITLE
Add a getter for the inner tracing-subscriber's `Layer`

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -36,12 +36,6 @@ where
         )
     }
 
-    /// Returns the inner `tracing_suscriber`'s [`Layer`](tracing_subscriber::layer::Layer), in
-    /// case wrapping it into a [`Registry`](registry::Registry) is undesired.
-    pub fn inner(self) -> impl layer::Layer<S> {
-        self.0
-    }
-
     /// Returns a new [`Layer`] with the given tag and using the given [Android
     /// log buffer](Buffer).
     pub fn with_buffer(tag: impl ToString, buffer: Buffer) -> Self {
@@ -176,5 +170,11 @@ impl<S, N, E> Layer<S, N, E> {
         let Self(inner) = self;
         let inner = inner.fmt_fields(fmt_fields);
         Layer(inner)
+    }
+
+    /// Returns the inner `tracing_suscriber`'s [`Layer`](tracing_subscriber::layer::Layer), in
+    /// case wrapping it into a [`Registry`](registry::Registry) is undesired.
+    pub fn inner(self) -> fmt::Layer<S, N, format::Format<E, ()>, AndroidLogMakeWriter> {
+        self.0
     }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -36,6 +36,12 @@ where
         )
     }
 
+    /// Returns the inner `tracing_suscriber`'s [`Layer`](tracing_subscriber::layer::Layer), in
+    /// case wrapping it into a [`Registry`](registry::Registry) is undesired.
+    pub fn inner(self) -> impl layer::Layer<S> {
+        self.0
+    }
+
     /// Returns a new [`Layer`] with the given tag and using the given [Android
     /// log buffer](Buffer).
     pub fn with_buffer(tag: impl ToString, buffer: Buffer) -> Self {
@@ -98,7 +104,7 @@ where
         Self(inner)
     }
 
-    /// See [`tracing_subscriber` documentation](fmt::Layer::with_target)    
+    /// See [`tracing_subscriber` documentation](fmt::Layer::with_target)
     pub fn with_target(self, display_target: bool) -> Self {
         let Self(inner) = self;
         let inner = inner.with_target(display_target);


### PR DESCRIPTION
Before this commit, the only way to effectively consume the layer
created with this crate is to use the `subscriber()` method that wraps
the layer into a `Registry`. This might not always be desired by end
users of this crate, so this commit adds a new way to retrieve the inner
tracing's `Layer` so one can add it into an existing Registry, for
instance.