### PR TITLE
Upgrade ndk-sys to v0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ lazy_static = "1"
 smallvec = "1"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk-sys = "0.2"
+ndk-sys = "0.3"
 
 [features]
 api-30 = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paranoid-android"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2018"
 authors = ["Raphaël Thériault <self@raftar.io>"]
 description = "Integration layer between tracing and Android logs"


### PR DESCRIPTION
Upgrades to the latest `ndk-sys` v0.3.0 that is starting to be used more widely in the community now.

Also bumped the major version of the crate, though let me know if you would prefer to have that done in a separate PR/commit after this is merged instead.