### PR TITLE
Update to NDK 23 also for the docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: nttld/setup-ndk@v1
         id: setup-ndk
         with:
-          ndk-version: r21e
+          ndk-version: r23c
       - uses: actions-rs/cargo@v1
         with:
           command: install


### PR DESCRIPTION
Follow up to https://github.com/raftario/paranoid-android/pull/6 to fix the `Docs` workflow, which can be seen failing [here](https://github.com/raftario/paranoid-android/actions/runs/8655091954/job/23733485248) due to NDK 23 now being required.